### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 asgiref==3.6.0
-backports.zoneinfo==0.2.1
+backports.zoneinfo==0.2.1;python_version<"3.9"
 Django==4.1.7
 sqlparse==0.4.3


### PR DESCRIPTION
backports.zoneinfo is not needed with python 3.9 or higher and may cause installation problems!